### PR TITLE
Fix for default logger.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -186,8 +186,7 @@ NOTE: All projects should set this as we may make this default in a future major
 
 If you need to use EU buckets, then add the following to establish_connection (replace my-bucket with the name of your bucket):
 
-   :s3_bucket => "my-bucket@s3.amazonaws.com",
-   :s3_bucket_headers => {:location => "eu"}
+    :s3_bucket => "my-bucket@s3.amazonaws.com", :s3_bucket_headers => {:location => "eu"}
 
 ### Created and Updated At Columns
 

--- a/README.markdown
+++ b/README.markdown
@@ -184,6 +184,11 @@ For rails, be sure to add this to your Application controller if using per_threa
 NOTE: All projects should set this as we may make this default in a future major version (v3?). Existing projects should use
 :s3_bucket=>:
 
+If you need to use EU buckets, then add the following to establish_connection (replace my-bucket with the name of your bucket):
+
+   :s3_bucket => "my-bucket@s3.amazonaws.com",
+   :s3_bucket_headers => {:location => "eu"}
+
 ### Created and Updated At Columns
 
 The default uses the columns "created" and "updated" which unfortunately are not the same as ActiveRecord, which

--- a/lib/simple_record.rb
+++ b/lib/simple_record.rb
@@ -658,7 +658,8 @@ module SimpleRecord
     # options:
     #   :s3_bucket => :old/:new/"#{any_bucket_name}". :new if want to use new bucket. Defaults to :old for backwards compatability.
     def s3_bucket(create=false, options={})
-      s3.bucket(s3_bucket_name(options[:s3_bucket]), create)
+      headers = SimpleRecord.options[:s3_bucket_headers] || {}
+      s3.bucket(s3_bucket_name(options[:s3_bucket]), create, nil, headers)
     end
 
     def s3_bucket_name(s3_bucket_option=:old)


### PR DESCRIPTION
OK, limited time for me, so I re-added this commit here, couldn't figure out how to make two pull requests from the same branch.

Basically I was trying to figure out why SimpleRecord kept sending out massive log messages of JSON traffic even though I was working setting the log treshhold high. Wouldn't it be more intuitive to have both simple_record and the underlying aws using the same logger, instead of specifying a special logger for the connection? I've implemented that in the third commit as well as changed a few "puts" to logger.warn/debug.

So what do you think?
