### PR TITLE
Fixed SimpleRecord::Base::find NoMethodError

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 --- 
 :major: 2
 :minor: 1
-:patch: 6
+:patch: 7
 :build: 

--- a/lib/simple_record/active_sdb.rb
+++ b/lib/simple_record/active_sdb.rb
@@ -633,7 +633,7 @@ module SimpleRecord
 
         # This will currently return and's, or's and betweens. Doesn't hurt anything, but could remove.
         def parse_condition_fields(conditions)
-          return nil unless conditions && conditions.present?
+          return nil unless conditions && conditions.present? && conditions.is_a?(Array)
           rx = /\b(\w*)[\s|>=|<=|!=|=|>|<|like|between]/
           fields = conditions[0].scan(rx)
 #                    puts 'condition_fields = ' + fields.inspect

--- a/simple_record.gemspec
+++ b/simple_record.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{simple_record}
-  s.version = "2.1.6"
+  s.version = "2.1.7"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Travis Reeder", "Chad Arimura", "RightScale"]
-  s.date = %q{2011-05-08}
+  s.date = %q{2011-06-09}
   s.description = %q{ActiveRecord like interface for Amazon SimpleDB. Store, query, shard, etc. By http://www.appoxy.com}
   s.email = %q{travis@appoxy.com}
   s.extra_rdoc_files = [


### PR DESCRIPTION
Fixed Rails 3 scaffolding support by allowing arrays to be passed to parse_condition_fields as per Chad Etzel's discovery at http://groups.google.com/group/simple-record/browse_thread/thread/48aaf9617ea363f

Error shown when attempting to execute  SimpleRecord::Base::find, generated by a Rails 3 scaffold:
NoMethodError (private method `scan' called for 40:Fixnum)

Reproducible by scaffolding in Rails 3, and changing model to inherit the SimpleRecord::Base class, then attempting to view the generated scaffold's edit, show, or delete views.
